### PR TITLE
make it so mount calls work in the nomad container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -102,6 +102,8 @@ services:
     image: cypherpunkarmory/local-nomad:develop
     cap_add:
       - SYS_ADMIN
+    security_opt:
+      - apparmor:unconfined
     environment:
       NOMAD_DATA_DIR: /tmp/nomad/data
       NOMAD_RUN_ROOT: 1


### PR DESCRIPTION
## What changes does this PR introduce?
Gets around apparmor issues when running the nomad container on a linux box with a newer kernel

## Any background context you want to provide?
We never tried to run local on linux before

## Where should the reviewer start?
The two lines that were changed

## Has this been manually tested? How?
`docker-compose up`
on a linux machine

## What value does this provide to our end users?
Being able to run locally, helps with our open source push

## What GIF best describes this PR or how it makes you feel?
![Take that apparmor](http://giphygifs.s3.amazonaws.com/media/12VIVqUkLt0orC/giphy.gif)
