### PR TITLE
Fix - Box Time Limit

### DIFF
--- a/app/services/box.py
+++ b/app/services/box.py
@@ -25,12 +25,12 @@ class BoxCreationService:
         current_user: User,
         config_id: Optional[int],
         ssh_key: str,
-        session_length: int = 30,  # minutes
+        session_length: int = 1800 # seconds
     ):
 
         self.ssh_key = ssh_key
         self.current_user = current_user
-        self.session_end_time = datetime.utcnow() + timedelta(minutes=session_length)
+        self.session_end_time = datetime.utcnow() + timedelta(seconds=session_length)
         self.session_length = session_length
 
         if config_id:


### PR DESCRIPTION
## What changes does this PR introduce?
This PR will fix the countdown value when using a Userland Cloud box.

## Any background context you want to provide?
Currently the timer will show 30 seconds in the top right corner even though it is being destroyed after 30 minutes.  


## Where should the reviewer start?
` app/services/box.py `

## Has this been manually tested? How?
Manually created a box and looked at the timer.

## What value does this provide to our end users?
This will allow users to know that their box lasts 30 minutes.

## What GIF best describes this PR or how it makes you feel?
![](https://media.giphy.com/media/3orieKO0FZN1RU99Hq/giphy.gif)
